### PR TITLE
Makefile config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ junit/
 
 # Release files
 releases/
+
+# config.mk for the Makefile - contains configuration specific to the developer
+config.mk

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,14 @@
-.PHONY: ankienv ankisync init serve docker_push deploy undeploy health_local
+CONFIG_FILES = config-default.mk $(wildcard config.mk)
+include $(CONFIG_FILES)
 
-PHRASIFY_VERSION := 0.1.0
-CHAIN_API_PORT := 8800
-IMAGE := phrasify
-WIN_APPDATA := $(shell wslpath "$$(wslvar APPDATA)")
-ANKI_ADDON_PATH := ${WIN_APPDATA}/Anki2/addons21/phrasify
-ANKI_ADDON_COPY_ENV := "prod"
-RELEASE_FOLDER := "./releases"
-RELEASE_NAME := "Phrasify-v${PHRASIFY_VERSION}"
-SITE_PACKAGES_PATH = $(shell hatch run site_packages_path)
-REQUIREMENTS := charset_normalizer dotenv
-K8S_ENV?=dev
+ANKI_ADDON_PATH = ${ANKI_ADDONS_PATH}/${ANKI_ADDON_PACKAGE}
+RELEASE_NAME = "${ANKI_ADDON_NAME}-v${ANKI_ADDON_VERSION}"
 
+.PHONY: print-%
+print-%:
+	@echo $* = $($*)
+
+.PHONY: init
 init:
 	pre-commit install
 	pre-commit install --hook-type commit-msg
@@ -20,6 +17,7 @@ init:
 	hatch run ipykernel_install
 	hatch run nbstripout_install
 
+.PHONY: ankisync
 ankisync:
 	if [ ! -d ${ANKI_ADDON_PATH} ]; then \
 		mkdir -p ${ANKI_ADDON_PATH}; \
@@ -33,37 +31,47 @@ ankisync:
 		--exclude ".env" --exclude ".env.*"; \
 	done
 
+.PHONY: ankimeta
 ankimeta:
 	cp -f ./src/phrasify/meta.json ${ANKI_ADDON_PATH}/meta.json
 
+.PHONY: ankienv
 ankienv:
 	if [ $(ANKI_ADDON_COPY_ENV) != "" ]; then \
 		cp -f ./src/phrasify/user_files/.env.${ANKI_ADDON_COPY_ENV} ${ANKI_ADDON_PATH}/user_files/.env; \
 	fi
 
+.PHONY: ankidev
 ankidev: ankisync ankimeta ankienv
 
+.PHONY: build
 build: ANKI_ADDON_PATH="$(RELEASE_FOLDER)/$(RELEASE_NAME)"
 build: ankisync
 	cd $(ANKI_ADDON_PATH) && zip -r9 ../${RELEASE_NAME}.ankiaddon .
 
+.PHONY: clean
 clean:
 	rm -rf $(RELEASE_FOLDER)
 
+.PHONY: serve
 serve:
 	uvicorn src.phrasify_api.main:app --port $(CHAIN_API_PORT) --reload
 
+.PHONY: docker_run
 docker_run:
 	docker build -t mathijsvdv/${IMAGE} .
 	docker run --name phrasify -p 8800:8800  mathijsvdv/${IMAGE}
 
+.PHONY: docker_push
 docker_push:
 	docker build -t mathijsvdv/${IMAGE} .
 	docker push mathijsvdv/${IMAGE}
 
+.PHONY: docker_run_ollama
 docker_run_ollama:
 	docker run -d --gpus=all -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
 
+.PHONY: deploy
 # When deploying to `minikube` be sure to run `minikube tunnel` in a separate terminal first
 deploy:
 	kubectl apply -f ./k8s/namespaces.yaml
@@ -71,15 +79,19 @@ deploy:
 	kubectl apply -f ./k8s/apps/ollama.yaml
 	kubectl apply -f ./k8s/apps/phrasify.yaml
 
+.PHONY: deploy_ollama
 deploy_ollama:
 	kubectl apply -f ./k8s/namespaces.yaml
 	kubectl apply -f ./k8s/apps/ollama.yaml
 
+.PHONY: undeploy
 undeploy:
 	kubectl delete -f ./k8s/apps/phrasify.yaml
 
+.PHONY: undeploy_ollama
 undeploy_ollama:
 	kubectl delete -f ./k8s/apps/ollama.yaml
 
+.PHONY: health_local
 health_local:
 	curl -X GET "http://localhost:$(CHAIN_API_PORT)/health"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ For example, say I'm trying to learn the Ukrainian word "дарувати" (to g
 - [Development](#development)
     - [Setting up the development environment](#setting-up-the-development-environment)
     - [Running tests](#running-tests)
-    - [Windows installation, WSL development only - Applying the current code to your Anki installation](#windows-installation-wsl-development-only---applying-the-current-code-to-your-anki-installation)
+    - [Applying the current code to your Anki installation](#applying-the-current-code-to-your-anki-installation)
+    - [Debugging the add-on](#debugging-the-add-on)
     - [Building the add-on](#building-the-add-on)
     - [Branching strategy](#branching-strategy)
 
@@ -114,7 +115,7 @@ In the directory `src/phrasify/user_files` you need to create two files:
 
 The `INIT_PHRASIFY_ADDON` environment variable is used to determine whether the field filters from the
 add-on should be initialized. We want to disable this in the development environment where
-the unit tests are run, but enable it when testing the add-on in Anki (i.e. when [applying the current code to your Anki installation](#windows-installation-wsl-development-only---applying-the-current-code-to-your-anki-installation)).
+the unit tests are run, but enable it when testing the add-on in Anki (i.e. when [applying the current code to your Anki installation](#applying-the-current-code-to-your-anki-installation)).
 
 ### Running tests
 To run the tests, run:
@@ -127,7 +128,7 @@ Running the tests with code coverage can be done using:
 hatch run test:cov
 ```
 
-### Windows installation, WSL development only - Applying the current code to your Anki installation
+### Applying the current code to your Anki installation
 To apply the current development code to your Anki installation, run:
 ```bash
 make ankidev
@@ -135,12 +136,24 @@ make ankidev
 
 This copies the current code to your Anki add-ons folder. You can then restart Anki to see the changes.
 
+> [!NOTE] Configuration for non-Windows users
+> The `ankidev` rule (indirectly) makes use of the `ANKI_ADDONS_PATH` variable, defined in
+> `config-default.mk`. This variable is set to the default Anki add-ons folder on Windows with WSL.
+> For Linux and MacOS users, you need to override this by setting `ANKI_ADDONS_PATH` in
+> `config.mk` (which is gitignored) to the path of your Anki add-ons folder. You can find the
+> folder by going to `Tools` > `Add-ons` > `View Files` in Anki. Place the following line in
+> `config.mk`:
+> ```Makefile
+> ANKI_ADDONS_PATH = /path/to/your/anki/addons/folder
+> ```
+
+
 ### Debugging the add-on
 For debugging the add-on, it helps to have a console open which shows all logging and print output. See https://addon-docs.ankiweb.net/console-output.html#showing-the-console for more information.
 
 The logging level can be set in the /src/phrasify/logging_config.json file. The
 default logging level is "INFO", but you can set it to "DEBUG" for more detailed logging
-and subsequently [apply it to your Anki installation](#windows-installation-wsl-development-only---applying-the-current-code-to-your-anki-installation).
+and subsequently [apply it to your Anki installation](#applying-the-current-code-to-your-anki-installation).
 
 ### Building the add-on
 To build the add-on, run:

--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ make ankidev
 
 This copies the current code to your Anki add-ons folder. You can then restart Anki to see the changes.
 
-> [!NOTE] Configuration for non-Windows users
-> The `ankidev` rule (indirectly) makes use of the `ANKI_ADDONS_PATH` variable, defined in
-> `config-default.mk`. This variable is set to the default Anki add-ons folder on Windows with WSL.
+> **Note for Linux and MacOS users**: The `ankidev` rule (indirectly) makes use of the `ANKI_ADDONS_PATH` variable, defined in
+> `config-default.mk`. This variable is set to the default Anki add-ons folder on Windows with WSL. This means that the `ankidev` rule only works out of the box for Windows with WSL.
+>
 > For Linux and MacOS users, you need to override this by setting `ANKI_ADDONS_PATH` in
 > `config.mk` (which is gitignored) to the path of your Anki add-ons folder. You can find the
 > folder by going to `Tools` > `Add-ons` > `View Files` in Anki. Place the following line in
-> `config.mk`:
+> `config.mk` (create it if it doesn't exist):
 > ```Makefile
 > ANKI_ADDONS_PATH = /path/to/your/anki/addons/folder
 > ```

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ make ankidev
 
 This copies the current code to your Anki add-ons folder. You can then restart Anki to see the changes.
 
-> **Note for Linux and MacOS users**: The `ankidev` rule (indirectly) makes use of the `ANKI_ADDONS_PATH` variable, defined in
+> **Important for Linux and MacOS users**: The `ankidev` rule (indirectly) makes use of the `ANKI_ADDONS_PATH` variable, defined in
 > `config-default.mk`. This variable is set to the default Anki add-ons folder on Windows with WSL. This means that the `ankidev` rule only works out of the box for Windows with WSL.
 >
 > For Linux and MacOS users, you need to override this by setting `ANKI_ADDONS_PATH` in

--- a/config-default.mk
+++ b/config-default.mk
@@ -1,0 +1,12 @@
+ANKI_ADDON_NAME = Phrasify
+ANKI_ADDON_PACKAGE = phrasify
+ANKI_ADDON_VERSION = 0.1.0
+RELEASE_FOLDER = "./releases"
+WIN_APPDATA = $(shell wslpath "$$(wslvar APPDATA)")
+ANKI_ADDONS_PATH = ${WIN_APPDATA}/Anki2/addons21
+SITE_PACKAGES_PATH = $(shell hatch run site_packages_path)
+REQUIREMENTS = charset_normalizer dotenv
+ANKI_ADDON_COPY_ENV = "prod"
+CHAIN_API_PORT = 8800
+IMAGE = phrasify
+K8S_ENV?=dev


### PR DESCRIPTION
Add `config-default.mk` to configure the `Makefile`. Linux and MacOS users can add a `config.mk` file to change the configuration (e.g. to reflect the Anki Add-on path for the `ankidev` Makefile rule)